### PR TITLE
Split site into multiple HTML pages

### DIFF
--- a/kontakt.html
+++ b/kontakt.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Välkommen, denna sida är under utveckling</title>
+  <title>Kontakt</title>
   <!-- Google Fonts -->
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;600&family=Manrope:wght@300;400;600&display=swap" rel="stylesheet">
@@ -12,7 +12,6 @@
 <body>
 <header class="site-header">
   <div class="brand">
-    <!-- Liten handritad känsla med enkel SVG-blomma -->
     <svg class="flower" viewBox="0 0 64 32" aria-hidden="true">
       <path d="M2 16 C10 10, 18 6, 32 16 C46 26, 54 22, 62 16" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/>
       <circle cx="32" cy="16" r="1.6" />
@@ -20,7 +19,6 @@
     <span class="brand-text">Välkommen, denna sida är under utveckling</span>
   </div>
 
-  <!-- Desktop meny -->
   <nav class="nav">
     <ul class="menu">
       <li class="menu-item has-dropdown">
@@ -35,7 +33,6 @@
     </ul>
   </nav>
 
-  <!-- Mobil hamburger -->
   <input type="checkbox" id="nav-toggle" class="nav-toggle" aria-label="Öppna meny">
   <label for="nav-toggle" class="hamburger" aria-hidden="true">
     <span></span><span></span><span></span>
@@ -50,26 +47,35 @@
 
 <hr class="divider" aria-hidden="true">
 
-<main class="container">
-  <article class="intro">
-    <h1>Psykologtjänster </h1>
+<section class="section">
+  <div class="section-inner">
+    <h2>Kontakt</h2>
     <p>
-      Här kommer texten vara… En kort introduktion om mottagningen,
-      arbetssätt och hur man kan ta kontakt.
+      Mejla <a href="mailto:härkommermailadressframöver ">härkommermailadressframöver</a>.
     </p>
-    <p>
-      Välkommen att höra av dig.
-    </p>
-    <a class="cta" href="kontakt.html">Boka samtal</a>
-  </article>
-</main>
+    <form class="contact-form" action="#" method="post">
+      <label>
+        Namn
+        <input type="text" name="namn" placeholder="Ditt namn" required>
+      </label>
+      <label>
+        E-post
+        <input type="email" name="email" placeholder="namn@mail.se" required>
+      </label>
+      <label>
+        Meddelande
+        <textarea name="msg" rows="5" placeholder="Vad vill du ha hjälp med?"></textarea>
+      </label>
+   <!--    <button type="submit">Skicka</button> -->
+    </form>
+  </div>
+</section>
 
 <footer class="site-footer">
   <p>&copy; <span id="year"></span> Maja Ludvigsen.</p>
 </footer>
 
 <script>
-  // Uppdatera årtal i foten
   document.getElementById('year').textContent = new Date().getFullYear();
 </script>
 </body>

--- a/om-mig.html
+++ b/om-mig.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Välkommen, denna sida är under utveckling</title>
+  <title>Om Maja</title>
   <!-- Google Fonts -->
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;600&family=Manrope:wght@300;400;600&display=swap" rel="stylesheet">
@@ -20,7 +20,6 @@
     <span class="brand-text">Välkommen, denna sida är under utveckling</span>
   </div>
 
-  <!-- Desktop meny -->
   <nav class="nav">
     <ul class="menu">
       <li class="menu-item has-dropdown">
@@ -35,7 +34,6 @@
     </ul>
   </nav>
 
-  <!-- Mobil hamburger -->
   <input type="checkbox" id="nav-toggle" class="nav-toggle" aria-label="Öppna meny">
   <label for="nav-toggle" class="hamburger" aria-hidden="true">
     <span></span><span></span><span></span>
@@ -50,26 +48,22 @@
 
 <hr class="divider" aria-hidden="true">
 
-<main class="container">
-  <article class="intro">
-    <h1>Psykologtjänster </h1>
+<section class="section">
+  <div class="section-inner">
+    <h2>Om Maja</h2>
     <p>
-      Här kommer texten vara… En kort introduktion om mottagningen,
-      arbetssätt och hur man kan ta kontakt.
+      Jag är legitimerad psykolog med bred yrkeserfarenhet från flera olika verksamhetsområden – bland annat neuropsykiatri, elevhälsa, digital psykologmottagning inom primärvården samt arbete inom social sektor i kommunala verksamheter.<br><br>
+I mitt nuvarande arbete inom kommunen ansvarar jag bland annat för handledning och utbildning av personal. Jag har också lång erfarenhet av att ge stöd vid kris, arbeta med stressrelaterad ohälsa samt erbjuda föräldrastöd.<br><br>
+Utöver mitt psykologarbete har jag en bakgrund inom sjöfart och segling, och var under några år även engagerad i Svenska Sjöräddningssällskapet – något som har gett mig värdefulla perspektiv på ledarskap, samarbete och att möta människor i utsatta situationer.<br><br>
     </p>
-    <p>
-      Välkommen att höra av dig.
-    </p>
-    <a class="cta" href="kontakt.html">Boka samtal</a>
-  </article>
-</main>
+  </div>
+</section>
 
 <footer class="site-footer">
   <p>&copy; <span id="year"></span> Maja Ludvigsen.</p>
 </footer>
 
 <script>
-  // Uppdatera årtal i foten
   document.getElementById('year').textContent = new Date().getFullYear();
 </script>
 </body>

--- a/tjanster.html
+++ b/tjanster.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Välkommen, denna sida är under utveckling</title>
+  <title>Tjänster</title>
   <!-- Google Fonts -->
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;600&family=Manrope:wght@300;400;600&display=swap" rel="stylesheet">
@@ -12,7 +12,6 @@
 <body>
 <header class="site-header">
   <div class="brand">
-    <!-- Liten handritad känsla med enkel SVG-blomma -->
     <svg class="flower" viewBox="0 0 64 32" aria-hidden="true">
       <path d="M2 16 C10 10, 18 6, 32 16 C46 26, 54 22, 62 16" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/>
       <circle cx="32" cy="16" r="1.6" />
@@ -20,7 +19,6 @@
     <span class="brand-text">Välkommen, denna sida är under utveckling</span>
   </div>
 
-  <!-- Desktop meny -->
   <nav class="nav">
     <ul class="menu">
       <li class="menu-item has-dropdown">
@@ -35,7 +33,6 @@
     </ul>
   </nav>
 
-  <!-- Mobil hamburger -->
   <input type="checkbox" id="nav-toggle" class="nav-toggle" aria-label="Öppna meny">
   <label for="nav-toggle" class="hamburger" aria-hidden="true">
     <span></span><span></span><span></span>
@@ -50,26 +47,20 @@
 
 <hr class="divider" aria-hidden="true">
 
-<main class="container">
-  <article class="intro">
-    <h1>Psykologtjänster </h1>
-    <p>
-      Här kommer texten vara… En kort introduktion om mottagningen,
-      arbetssätt och hur man kan ta kontakt.
+<section class="section alt">
+  <div class="section-inner">
+    <h2>Tjänster</h2>
+    <p>Jag erbjuder psykologisk kompetens för organisationer, företag och yrkesverksamma – med fokus på hållbar arbetsmiljö, professionell utveckling och psykologiskt informerade insatser. Min tjänster innefattar bland annat handledning, utbildning, föreläsningar samt konsultation vid kriser eller förändringsprocesser.<br><br>
+Med ett tydligt fokus på både individ och system vill jag bidra till ökad förståelse, förbättrad kommunikation och långsiktig utveckling i de sammanhang där jag verkar.<br><br>
     </p>
-    <p>
-      Välkommen att höra av dig.
-    </p>
-    <a class="cta" href="kontakt.html">Boka samtal</a>
-  </article>
-</main>
+  </div>
+</section>
 
 <footer class="site-footer">
   <p>&copy; <span id="year"></span> Maja Ludvigsen.</p>
 </footer>
 
 <script>
-  // Uppdatera årtal i foten
   document.getElementById('year').textContent = new Date().getFullYear();
 </script>
 </body>


### PR DESCRIPTION
## Summary
- Refactor single-page layout into separate HTML files for home, about, services, and contact content.
- Update navigation and call-to-action links to navigate seamlessly between pages.

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7db11882c83339b3f6dd833370131