### PR TITLE
Replace dropdown menu with visible navigation bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,15 +23,10 @@
   <!-- Desktop meny -->
   <nav class="nav">
     <ul class="menu">
-      <li class="menu-item has-dropdown">
-        <a href="#" class="menu-link">Meny</a>
-        <div class="dropdown">
-          <a href="index.html">Hem</a>
-          <a href="om-mig.html">Om mig</a>
-          <a href="tjanster.html">Tjänster</a>
-          <a href="kontakt.html">Kontakt</a>
-        </div>
-      </li>
+      <li><a href="index.html" class="menu-link" aria-current="page">Hem</a></li>
+      <li><a href="om-mig.html" class="menu-link">Om mig</a></li>
+      <li><a href="tjanster.html" class="menu-link">Tjänster</a></li>
+      <li><a href="kontakt.html" class="menu-link">Kontakt</a></li>
     </ul>
   </nav>
 
@@ -41,7 +36,7 @@
     <span></span><span></span><span></span>
   </label>
   <nav class="mobile-drawer">
-    <a href="index.html">Hem</a>
+    <a href="index.html" aria-current="page">Hem</a>
     <a href="om-mig.html">Om mig</a>
     <a href="tjanster.html">Tjänster</a>
     <a href="kontakt.html">Kontakt</a>

--- a/kontakt.html
+++ b/kontakt.html
@@ -21,15 +21,10 @@
 
   <nav class="nav">
     <ul class="menu">
-      <li class="menu-item has-dropdown">
-        <a href="#" class="menu-link">Meny</a>
-        <div class="dropdown">
-          <a href="index.html">Hem</a>
-          <a href="om-mig.html">Om mig</a>
-          <a href="tjanster.html">Tjänster</a>
-          <a href="kontakt.html">Kontakt</a>
-        </div>
-      </li>
+      <li><a href="index.html" class="menu-link">Hem</a></li>
+      <li><a href="om-mig.html" class="menu-link">Om mig</a></li>
+      <li><a href="tjanster.html" class="menu-link">Tjänster</a></li>
+      <li><a href="kontakt.html" class="menu-link" aria-current="page">Kontakt</a></li>
     </ul>
   </nav>
 
@@ -41,7 +36,7 @@
     <a href="index.html">Hem</a>
     <a href="om-mig.html">Om mig</a>
     <a href="tjanster.html">Tjänster</a>
-    <a href="kontakt.html">Kontakt</a>
+    <a href="kontakt.html" aria-current="page">Kontakt</a>
   </nav>
 </header>
 

--- a/om-mig.html
+++ b/om-mig.html
@@ -22,15 +22,10 @@
 
   <nav class="nav">
     <ul class="menu">
-      <li class="menu-item has-dropdown">
-        <a href="#" class="menu-link">Meny</a>
-        <div class="dropdown">
-          <a href="index.html">Hem</a>
-          <a href="om-mig.html">Om mig</a>
-          <a href="tjanster.html">Tjänster</a>
-          <a href="kontakt.html">Kontakt</a>
-        </div>
-      </li>
+      <li><a href="index.html" class="menu-link">Hem</a></li>
+      <li><a href="om-mig.html" class="menu-link" aria-current="page">Om mig</a></li>
+      <li><a href="tjanster.html" class="menu-link">Tjänster</a></li>
+      <li><a href="kontakt.html" class="menu-link">Kontakt</a></li>
     </ul>
   </nav>
 
@@ -40,7 +35,7 @@
   </label>
   <nav class="mobile-drawer">
     <a href="index.html">Hem</a>
-    <a href="om-mig.html">Om mig</a>
+    <a href="om-mig.html" aria-current="page">Om mig</a>
     <a href="tjanster.html">Tjänster</a>
     <a href="kontakt.html">Kontakt</a>
   </nav>

--- a/style.css
+++ b/style.css
@@ -52,38 +52,27 @@ body{
   border:0; margin:0;
 }
 
-/* Desktop nav with hover dropdown */
+/* Desktop navigation */
 .nav{ display:none; }
 @media (min-width:840px){
   .nav{ display:block; }
 }
 
 .menu{
-  list-style:none; margin:0; padding:0; display:flex; gap:1rem;
+  list-style:none; margin:0; padding:0; display:flex; gap:1.5rem;
 }
 .menu-link{
-  display:inline-block; padding:.5rem .75rem; border-radius:999px;
+  display:inline-block; padding:.5rem .9rem; border-radius:999px;
   text-decoration:none; color:var(--ink);
   border:1px solid transparent;
+  font-family:"Manrope", system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji","Segoe UI Emoji";
+  font-weight:600;
+  font-size:1rem;
 }
-.menu-link:hover{ border-color:var(--ring); background:var(--mist); }
-
-/* Dropdown */
-.has-dropdown{ position:relative; }
-.dropdown{
-  position:absolute; right:0; top:calc(100% + .4rem);
-  display:none; min-width:210px;
-  background:var(--paper);
-  border:1px solid #dfe8e4;
-  box-shadow:0 10px 30px rgba(0,0,0,.08);
-  border-radius:16px; padding:.5rem;
+.menu-link:hover,
+.menu-link[aria-current="page"]{
+  border-color:var(--ring); background:var(--mist);
 }
-.dropdown a{
-  display:block; padding:.6rem .8rem; border-radius:12px;
-  color:var(--ink); text-decoration:none;
-}
-.dropdown a:hover{ background:var(--mist); }
-.has-dropdown:hover .dropdown{ display:block; }
 
 /* Mobile hamburger & drawer (CSS only) */
 .nav-toggle{ display:none; }
@@ -109,6 +98,7 @@ body{
 .mobile-drawer a{
   display:block; padding:.7rem .9rem; text-decoration:none; color:var(--ink);
   border-radius:12px;
+  font-weight:600;
 }
 .mobile-drawer a:hover{ background:var(--mist); }
 .nav-toggle:checked ~ .mobile-drawer{ display:block; }

--- a/tjanster.html
+++ b/tjanster.html
@@ -21,15 +21,10 @@
 
   <nav class="nav">
     <ul class="menu">
-      <li class="menu-item has-dropdown">
-        <a href="#" class="menu-link">Meny</a>
-        <div class="dropdown">
-          <a href="index.html">Hem</a>
-          <a href="om-mig.html">Om mig</a>
-          <a href="tjanster.html">Tjänster</a>
-          <a href="kontakt.html">Kontakt</a>
-        </div>
-      </li>
+      <li><a href="index.html" class="menu-link">Hem</a></li>
+      <li><a href="om-mig.html" class="menu-link">Om mig</a></li>
+      <li><a href="tjanster.html" class="menu-link" aria-current="page">Tjänster</a></li>
+      <li><a href="kontakt.html" class="menu-link">Kontakt</a></li>
     </ul>
   </nav>
 
@@ -40,7 +35,7 @@
   <nav class="mobile-drawer">
     <a href="index.html">Hem</a>
     <a href="om-mig.html">Om mig</a>
-    <a href="tjanster.html">Tjänster</a>
+    <a href="tjanster.html" aria-current="page">Tjänster</a>
     <a href="kontakt.html">Kontakt</a>
   </nav>
 </header>


### PR DESCRIPTION
## Summary
- replace dropdown menu with horizontal navigation bar on all pages
- style menu items to match existing fonts and highlight active page
- update mobile drawer links to use consistent font weight

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7e2726cb88333a9ef519ab03f0703