### PR TITLE
feat: add hand-drawn flower header icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,8 +14,7 @@
   <div class="brand">
     <!-- Liten handritad känsla med enkel SVG-blomma -->
     <svg class="flower" viewBox="0 0 64 32" aria-hidden="true">
-      <path d="M2 16 C10 10, 18 6, 32 16 C46 26, 54 22, 62 16" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/>
-      <circle cx="32" cy="16" r="1.6" />
+      <path d="M32 6 C28 2,24 2,22 6 C20 10,22 14,26 16 C24 20,28 20,32 18 C36 20,40 20,38 16 C42 14,44 10,42 6 C40 2,36 2,32 6 Z M32 18 V30 M32 22 C30 24,28 24,26 22 M32 22 C34 24,36 24,38 22" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
     </svg>
     <span class="brand-text">Maja Ludvigsen</span>
   </div>

--- a/kontakt.html
+++ b/kontakt.html
@@ -13,8 +13,7 @@
 <header class="site-header">
   <div class="brand">
     <svg class="flower" viewBox="0 0 64 32" aria-hidden="true">
-      <path d="M2 16 C10 10, 18 6, 32 16 C46 26, 54 22, 62 16" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/>
-      <circle cx="32" cy="16" r="1.6" />
+      <path d="M32 6 C28 2,24 2,22 6 C20 10,22 14,26 16 C24 20,28 20,32 18 C36 20,40 20,38 16 C42 14,44 10,42 6 C40 2,36 2,32 6 Z M32 18 V30 M32 22 C30 24,28 24,26 22 M32 22 C34 24,36 24,38 22" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
     </svg>
     <span class="brand-text">Maja Ludvigsen</span>
   </div>

--- a/om-mig.html
+++ b/om-mig.html
@@ -14,8 +14,7 @@
   <div class="brand">
     <!-- Liten handritad känsla med enkel SVG-blomma -->
     <svg class="flower" viewBox="0 0 64 32" aria-hidden="true">
-      <path d="M2 16 C10 10, 18 6, 32 16 C46 26, 54 22, 62 16" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/>
-      <circle cx="32" cy="16" r="1.6" />
+      <path d="M32 6 C28 2,24 2,22 6 C20 10,22 14,26 16 C24 20,28 20,32 18 C36 20,40 20,38 16 C42 14,44 10,42 6 C40 2,36 2,32 6 Z M32 18 V30 M32 22 C30 24,28 24,26 22 M32 22 C34 24,36 24,38 22" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
     </svg>
     <span class="brand-text">Maja Ludvigsen</span>
   </div>

--- a/tjanster.html
+++ b/tjanster.html
@@ -13,8 +13,7 @@
 <header class="site-header">
   <div class="brand">
     <svg class="flower" viewBox="0 0 64 32" aria-hidden="true">
-      <path d="M2 16 C10 10, 18 6, 32 16 C46 26, 54 22, 62 16" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/>
-      <circle cx="32" cy="16" r="1.6" />
+      <path d="M32 6 C28 2,24 2,22 6 C20 10,22 14,26 16 C24 20,28 20,32 18 C36 20,40 20,38 16 C42 14,44 10,42 6 C40 2,36 2,32 6 Z M32 18 V30 M32 22 C30 24,28 24,26 22 M32 22 C34 24,36 24,38 22" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
     </svg>
     <span class="brand-text">Maja Ludvigsen</span>
   </div>


### PR DESCRIPTION
## Summary
- replace placeholder arc with a simple hand-drawn style flower
- apply new flower icon to all page headers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c80a86a4e083339dae0cd2f116420b