### PR TITLE
Add decorative header branding

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,12 +11,50 @@
 </head>
 <body>
 <header class="site-header">
-  <div class="brand">
-    <!-- Liten handritad känsla med enkel SVG-blomma -->
-    <svg class="flower" viewBox="0 0 64 32" aria-hidden="true">
-      <path d="M32 6 C28 2,24 2,22 6 C20 10,22 14,26 16 C24 20,28 20,32 18 C36 20,40 20,38 16 C42 14,44 10,42 6 C40 2,36 2,32 6 Z M32 18 V30 M32 22 C30 24,28 24,26 22 M32 22 C34 24,36 24,38 22" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+  <div class="header-decor">
+    <svg class="flower" xmlns="http://www.w3.org/2000/svg" viewBox="-12 -12 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <circle r="1.6" fill="currentColor"/>
+      <g>
+        <path d="M0,-7 C 1.8,-7 3.0,-4.6 0,-3  -3.0,-4.6 -1.8,-7 0,-7 Z" />
+        <g transform="rotate(72)">
+          <path d="M0,-7 C 1.8,-7 3.0,-4.6 0,-3  -3.0,-4.6 -1.8,-7 0,-7 Z" />
+        </g>
+        <g transform="rotate(144)">
+          <path d="M0,-7 C 1.8,-7 3.0,-4.6 0,-3  -3.0,-4.6 -1.8,-7 0,-7 Z" />
+        </g>
+        <g transform="rotate(216)">
+          <path d="M0,-7 C 1.8,-7 3.0,-4.6 0,-3  -3.0,-4.6 -1.8,-7 0,-7 Z" />
+        </g>
+        <g transform="rotate(288)">
+          <path d="M0,-7 C 1.8,-7 3.0,-4.6 0,-3  -3.0,-4.6 -1.8,-7 0,-7 Z" />
+        </g>
+      </g>
     </svg>
-    <span class="brand-text">Maja Ludvigsen</span>
+
+    <span class="line"></span>
+
+    <h1 class="site-title">Maja Ludvigsen</h1>
+
+    <span class="line"></span>
+
+    <svg class="flower" xmlns="http://www.w3.org/2000/svg" viewBox="-12 -12 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <circle r="1.6" fill="currentColor"/>
+      <g>
+        <path d="M0,-7 C 1.8,-7 3.0,-4.6 0,-3  -3.0,-4.6 -1.8,-7 0,-7 Z" />
+        <g transform="rotate(72)">
+          <path d="M0,-7 C 1.8,-7 3.0,-4.6 0,-3  -3.0,-4.6 -1.8,-7 0,-7 Z" />
+        </g>
+        <g transform="rotate(144)">
+          <path d="M0,-7 C 1.8,-7 3.0,-4.6 0,-3  -3.0,-4.6 -1.8,-7 0,-7 Z" />
+        </g>
+        <g transform="rotate(216)">
+          <path d="M0,-7 C 1.8,-7 3.0,-4.6 0,-3  -3.0,-4.6 -1.8,-7 0,-7 Z" />
+        </g>
+        <g transform="rotate(288)">
+          <path d="M0,-7 C 1.8,-7 3.0,-4.6 0,-3  -3.0,-4.6 -1.8,-7 0,-7 Z" />
+        </g>
+      </g>
+    </svg>
   </div>
 
   <!-- Desktop meny -->

--- a/kontakt.html
+++ b/kontakt.html
@@ -11,13 +11,53 @@
 </head>
 <body>
 <header class="site-header">
-  <div class="brand">
-    <svg class="flower" viewBox="0 0 64 32" aria-hidden="true">
-      <path d="M32 6 C28 2,24 2,22 6 C20 10,22 14,26 16 C24 20,28 20,32 18 C36 20,40 20,38 16 C42 14,44 10,42 6 C40 2,36 2,32 6 Z M32 18 V30 M32 22 C30 24,28 24,26 22 M32 22 C34 24,36 24,38 22" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+  <div class="header-decor">
+    <svg class="flower" xmlns="http://www.w3.org/2000/svg" viewBox="-12 -12 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <circle r="1.6" fill="currentColor"/>
+      <g>
+        <path d="M0,-7 C 1.8,-7 3.0,-4.6 0,-3  -3.0,-4.6 -1.8,-7 0,-7 Z" />
+        <g transform="rotate(72)">
+          <path d="M0,-7 C 1.8,-7 3.0,-4.6 0,-3  -3.0,-4.6 -1.8,-7 0,-7 Z" />
+        </g>
+        <g transform="rotate(144)">
+          <path d="M0,-7 C 1.8,-7 3.0,-4.6 0,-3  -3.0,-4.6 -1.8,-7 0,-7 Z" />
+        </g>
+        <g transform="rotate(216)">
+          <path d="M0,-7 C 1.8,-7 3.0,-4.6 0,-3  -3.0,-4.6 -1.8,-7 0,-7 Z" />
+        </g>
+        <g transform="rotate(288)">
+          <path d="M0,-7 C 1.8,-7 3.0,-4.6 0,-3  -3.0,-4.6 -1.8,-7 0,-7 Z" />
+        </g>
+      </g>
     </svg>
-    <span class="brand-text">Maja Ludvigsen</span>
+
+    <span class="line"></span>
+
+    <h1 class="site-title">Maja Ludvigsen</h1>
+
+    <span class="line"></span>
+
+    <svg class="flower" xmlns="http://www.w3.org/2000/svg" viewBox="-12 -12 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <circle r="1.6" fill="currentColor"/>
+      <g>
+        <path d="M0,-7 C 1.8,-7 3.0,-4.6 0,-3  -3.0,-4.6 -1.8,-7 0,-7 Z" />
+        <g transform="rotate(72)">
+          <path d="M0,-7 C 1.8,-7 3.0,-4.6 0,-3  -3.0,-4.6 -1.8,-7 0,-7 Z" />
+        </g>
+        <g transform="rotate(144)">
+          <path d="M0,-7 C 1.8,-7 3.0,-4.6 0,-3  -3.0,-4.6 -1.8,-7 0,-7 Z" />
+        </g>
+        <g transform="rotate(216)">
+          <path d="M0,-7 C 1.8,-7 3.0,-4.6 0,-3  -3.0,-4.6 -1.8,-7 0,-7 Z" />
+        </g>
+        <g transform="rotate(288)">
+          <path d="M0,-7 C 1.8,-7 3.0,-4.6 0,-3  -3.0,-4.6 -1.8,-7 0,-7 Z" />
+        </g>
+      </g>
+    </svg>
   </div>
 
+  <!-- Desktop meny -->
   <nav class="nav">
     <ul class="menu">
       <li><a href="index.html" class="menu-link">Hem</a></li>

--- a/om-mig.html
+++ b/om-mig.html
@@ -11,14 +11,53 @@
 </head>
 <body>
 <header class="site-header">
-  <div class="brand">
-    <!-- Liten handritad känsla med enkel SVG-blomma -->
-    <svg class="flower" viewBox="0 0 64 32" aria-hidden="true">
-      <path d="M32 6 C28 2,24 2,22 6 C20 10,22 14,26 16 C24 20,28 20,32 18 C36 20,40 20,38 16 C42 14,44 10,42 6 C40 2,36 2,32 6 Z M32 18 V30 M32 22 C30 24,28 24,26 22 M32 22 C34 24,36 24,38 22" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+  <div class="header-decor">
+    <svg class="flower" xmlns="http://www.w3.org/2000/svg" viewBox="-12 -12 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <circle r="1.6" fill="currentColor"/>
+      <g>
+        <path d="M0,-7 C 1.8,-7 3.0,-4.6 0,-3  -3.0,-4.6 -1.8,-7 0,-7 Z" />
+        <g transform="rotate(72)">
+          <path d="M0,-7 C 1.8,-7 3.0,-4.6 0,-3  -3.0,-4.6 -1.8,-7 0,-7 Z" />
+        </g>
+        <g transform="rotate(144)">
+          <path d="M0,-7 C 1.8,-7 3.0,-4.6 0,-3  -3.0,-4.6 -1.8,-7 0,-7 Z" />
+        </g>
+        <g transform="rotate(216)">
+          <path d="M0,-7 C 1.8,-7 3.0,-4.6 0,-3  -3.0,-4.6 -1.8,-7 0,-7 Z" />
+        </g>
+        <g transform="rotate(288)">
+          <path d="M0,-7 C 1.8,-7 3.0,-4.6 0,-3  -3.0,-4.6 -1.8,-7 0,-7 Z" />
+        </g>
+      </g>
     </svg>
-    <span class="brand-text">Maja Ludvigsen</span>
+
+    <span class="line"></span>
+
+    <h1 class="site-title">Maja Ludvigsen</h1>
+
+    <span class="line"></span>
+
+    <svg class="flower" xmlns="http://www.w3.org/2000/svg" viewBox="-12 -12 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <circle r="1.6" fill="currentColor"/>
+      <g>
+        <path d="M0,-7 C 1.8,-7 3.0,-4.6 0,-3  -3.0,-4.6 -1.8,-7 0,-7 Z" />
+        <g transform="rotate(72)">
+          <path d="M0,-7 C 1.8,-7 3.0,-4.6 0,-3  -3.0,-4.6 -1.8,-7 0,-7 Z" />
+        </g>
+        <g transform="rotate(144)">
+          <path d="M0,-7 C 1.8,-7 3.0,-4.6 0,-3  -3.0,-4.6 -1.8,-7 0,-7 Z" />
+        </g>
+        <g transform="rotate(216)">
+          <path d="M0,-7 C 1.8,-7 3.0,-4.6 0,-3  -3.0,-4.6 -1.8,-7 0,-7 Z" />
+        </g>
+        <g transform="rotate(288)">
+          <path d="M0,-7 C 1.8,-7 3.0,-4.6 0,-3  -3.0,-4.6 -1.8,-7 0,-7 Z" />
+        </g>
+      </g>
+    </svg>
   </div>
 
+  <!-- Desktop meny -->
   <nav class="nav">
     <ul class="menu">
       <li><a href="index.html" class="menu-link">Hem</a></li>

--- a/style.css
+++ b/style.css
@@ -44,6 +44,28 @@ body{
   letter-spacing:.02em;
   font-size:1.7rem;
 }
+.header-decor{
+  display:flex;
+  align-items:center;
+  gap:.6rem;
+  color:var(--accent);
+}
+.header-decor .flower{
+  width:24px; height:24px;
+}
+.header-decor .line{
+  flex:1;
+  height:1px;
+  background:var(--sage);
+}
+.header-decor .site-title{
+  font-family:"Cormorant Garamond", serif;
+  font-weight:600;
+  letter-spacing:.02em;
+  font-size:1.7rem;
+  margin:0;
+}
+
 
 /* Divider under header (tecknad linje-känsla) */
 .divider{

--- a/tjanster.html
+++ b/tjanster.html
@@ -11,13 +11,53 @@
 </head>
 <body>
 <header class="site-header">
-  <div class="brand">
-    <svg class="flower" viewBox="0 0 64 32" aria-hidden="true">
-      <path d="M32 6 C28 2,24 2,22 6 C20 10,22 14,26 16 C24 20,28 20,32 18 C36 20,40 20,38 16 C42 14,44 10,42 6 C40 2,36 2,32 6 Z M32 18 V30 M32 22 C30 24,28 24,26 22 M32 22 C34 24,36 24,38 22" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+  <div class="header-decor">
+    <svg class="flower" xmlns="http://www.w3.org/2000/svg" viewBox="-12 -12 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <circle r="1.6" fill="currentColor"/>
+      <g>
+        <path d="M0,-7 C 1.8,-7 3.0,-4.6 0,-3  -3.0,-4.6 -1.8,-7 0,-7 Z" />
+        <g transform="rotate(72)">
+          <path d="M0,-7 C 1.8,-7 3.0,-4.6 0,-3  -3.0,-4.6 -1.8,-7 0,-7 Z" />
+        </g>
+        <g transform="rotate(144)">
+          <path d="M0,-7 C 1.8,-7 3.0,-4.6 0,-3  -3.0,-4.6 -1.8,-7 0,-7 Z" />
+        </g>
+        <g transform="rotate(216)">
+          <path d="M0,-7 C 1.8,-7 3.0,-4.6 0,-3  -3.0,-4.6 -1.8,-7 0,-7 Z" />
+        </g>
+        <g transform="rotate(288)">
+          <path d="M0,-7 C 1.8,-7 3.0,-4.6 0,-3  -3.0,-4.6 -1.8,-7 0,-7 Z" />
+        </g>
+      </g>
     </svg>
-    <span class="brand-text">Maja Ludvigsen</span>
+
+    <span class="line"></span>
+
+    <h1 class="site-title">Maja Ludvigsen</h1>
+
+    <span class="line"></span>
+
+    <svg class="flower" xmlns="http://www.w3.org/2000/svg" viewBox="-12 -12 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <circle r="1.6" fill="currentColor"/>
+      <g>
+        <path d="M0,-7 C 1.8,-7 3.0,-4.6 0,-3  -3.0,-4.6 -1.8,-7 0,-7 Z" />
+        <g transform="rotate(72)">
+          <path d="M0,-7 C 1.8,-7 3.0,-4.6 0,-3  -3.0,-4.6 -1.8,-7 0,-7 Z" />
+        </g>
+        <g transform="rotate(144)">
+          <path d="M0,-7 C 1.8,-7 3.0,-4.6 0,-3  -3.0,-4.6 -1.8,-7 0,-7 Z" />
+        </g>
+        <g transform="rotate(216)">
+          <path d="M0,-7 C 1.8,-7 3.0,-4.6 0,-3  -3.0,-4.6 -1.8,-7 0,-7 Z" />
+        </g>
+        <g transform="rotate(288)">
+          <path d="M0,-7 C 1.8,-7 3.0,-4.6 0,-3  -3.0,-4.6 -1.8,-7 0,-7 Z" />
+        </g>
+      </g>
+    </svg>
   </div>
 
+  <!-- Desktop meny -->
   <nav class="nav">
     <ul class="menu">
       <li><a href="index.html" class="menu-link">Hem</a></li>


### PR DESCRIPTION
## Summary
- Replace old brand block with a decorative header featuring two SVG flowers, lines, and site title on all HTML pages
- Style new header elements in CSS for consistent appearance

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c82d13ef0c833387be31618005cbb0