### PR TITLE
Uppdatera headerns svg-dekorationer

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
 <body>
 <header class="site-header">
   <div class="header-decor">
+    <!-- vänster blomma -->
     <svg class="flower" xmlns="http://www.w3.org/2000/svg" viewBox="-12 -12 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
       <circle r="1.6" fill="currentColor"/>
       <g>
@@ -31,12 +32,19 @@
       </g>
     </svg>
 
-    <span class="line"></span>
+    <!-- vågig linje -->
+    <svg class="wave" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 10" preserveAspectRatio="none">
+      <path d="M0 5 Q 25 0, 50 5 T 100 5" fill="none" stroke="currentColor" stroke-width="1.5"/>
+    </svg>
 
     <h1 class="site-title">Maja Ludvigsen</h1>
 
-    <span class="line"></span>
+    <!-- vågig linje -->
+    <svg class="wave" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 10" preserveAspectRatio="none">
+      <path d="M0 5 Q 25 0, 50 5 T 100 5" fill="none" stroke="currentColor" stroke-width="1.5"/>
+    </svg>
 
+    <!-- höger blomma -->
     <svg class="flower" xmlns="http://www.w3.org/2000/svg" viewBox="-12 -12 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
       <circle r="1.6" fill="currentColor"/>
       <g>

--- a/kontakt.html
+++ b/kontakt.html
@@ -12,6 +12,7 @@
 <body>
 <header class="site-header">
   <div class="header-decor">
+    <!-- vänster blomma -->
     <svg class="flower" xmlns="http://www.w3.org/2000/svg" viewBox="-12 -12 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
       <circle r="1.6" fill="currentColor"/>
       <g>
@@ -31,12 +32,19 @@
       </g>
     </svg>
 
-    <span class="line"></span>
+    <!-- vågig linje -->
+    <svg class="wave" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 10" preserveAspectRatio="none">
+      <path d="M0 5 Q 25 0, 50 5 T 100 5" fill="none" stroke="currentColor" stroke-width="1.5"/>
+    </svg>
 
     <h1 class="site-title">Maja Ludvigsen</h1>
 
-    <span class="line"></span>
+    <!-- vågig linje -->
+    <svg class="wave" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 10" preserveAspectRatio="none">
+      <path d="M0 5 Q 25 0, 50 5 T 100 5" fill="none" stroke="currentColor" stroke-width="1.5"/>
+    </svg>
 
+    <!-- höger blomma -->
     <svg class="flower" xmlns="http://www.w3.org/2000/svg" viewBox="-12 -12 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
       <circle r="1.6" fill="currentColor"/>
       <g>

--- a/om-mig.html
+++ b/om-mig.html
@@ -12,6 +12,7 @@
 <body>
 <header class="site-header">
   <div class="header-decor">
+    <!-- vänster blomma -->
     <svg class="flower" xmlns="http://www.w3.org/2000/svg" viewBox="-12 -12 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
       <circle r="1.6" fill="currentColor"/>
       <g>
@@ -31,12 +32,19 @@
       </g>
     </svg>
 
-    <span class="line"></span>
+    <!-- vågig linje -->
+    <svg class="wave" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 10" preserveAspectRatio="none">
+      <path d="M0 5 Q 25 0, 50 5 T 100 5" fill="none" stroke="currentColor" stroke-width="1.5"/>
+    </svg>
 
     <h1 class="site-title">Maja Ludvigsen</h1>
 
-    <span class="line"></span>
+    <!-- vågig linje -->
+    <svg class="wave" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 10" preserveAspectRatio="none">
+      <path d="M0 5 Q 25 0, 50 5 T 100 5" fill="none" stroke="currentColor" stroke-width="1.5"/>
+    </svg>
 
+    <!-- höger blomma -->
     <svg class="flower" xmlns="http://www.w3.org/2000/svg" viewBox="-12 -12 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
       <circle r="1.6" fill="currentColor"/>
       <g>

--- a/style.css
+++ b/style.css
@@ -55,10 +55,11 @@ body{
 .header-decor .flower{
   width:24px; height:24px;
 }
-.header-decor .line {
+.header-decor .wave {
   flex: 1;
-  height: 1px;
-  background: linear-gradient(to right, transparent, currentColor, transparent);
+  height: 16px;
+  width: 100%;
+  display: block;
 }
 .header-decor .site-title {
   font-family: "Playfair Display", Georgia, serif;

--- a/tjanster.html
+++ b/tjanster.html
@@ -12,6 +12,7 @@
 <body>
 <header class="site-header">
   <div class="header-decor">
+    <!-- vänster blomma -->
     <svg class="flower" xmlns="http://www.w3.org/2000/svg" viewBox="-12 -12 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
       <circle r="1.6" fill="currentColor"/>
       <g>
@@ -31,12 +32,19 @@
       </g>
     </svg>
 
-    <span class="line"></span>
+    <!-- vågig linje -->
+    <svg class="wave" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 10" preserveAspectRatio="none">
+      <path d="M0 5 Q 25 0, 50 5 T 100 5" fill="none" stroke="currentColor" stroke-width="1.5"/>
+    </svg>
 
     <h1 class="site-title">Maja Ludvigsen</h1>
 
-    <span class="line"></span>
+    <!-- vågig linje -->
+    <svg class="wave" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 10" preserveAspectRatio="none">
+      <path d="M0 5 Q 25 0, 50 5 T 100 5" fill="none" stroke="currentColor" stroke-width="1.5"/>
+    </svg>
 
+    <!-- höger blomma -->
     <svg class="flower" xmlns="http://www.w3.org/2000/svg" viewBox="-12 -12 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
       <circle r="1.6" fill="currentColor"/>
       <g>


### PR DESCRIPTION
## Summary
- ersatte de raka linjerna i sidhuvudet med vågformade svg-element mellan blommorna på alla sidor
- justerade css så att de nya vågorna får rätt storlek och följer sidhuvudets färgsättning

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68c83e74217c833382be24ff22370fdd