### PR TITLE
Adjust header decor spacing

### DIFF
--- a/style.css
+++ b/style.css
@@ -57,7 +57,7 @@ body{
 }
 .header-decor .wave {
   flex: 1;
-  height: 16px;
+  height: 20px;
   width: 100%;
   display: block;
 }
@@ -65,7 +65,7 @@ body{
   font-family: "Playfair Display", Georgia, serif;
   font-size: 1.8rem;
   font-weight: 500;
-  margin: 0;
+  margin: 0 8px;
 }
 
 


### PR DESCRIPTION
## Summary
- increase the decorative wave height in the header to 20px for a bolder divider appearance.
- add horizontal margin to the header site title to match the updated spacing specification.

## Testing
- not run (static CSS update)


------
https://chatgpt.com/codex/tasks/task_e_68c840ade270833387fd30e7cde42ce7