### PR TITLE
Add flowing wave pattern to header decoration

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,15 +33,15 @@
     </svg>
 
     <!-- vågig linje -->
-    <svg class="wave" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 10" preserveAspectRatio="none">
-      <path d="M0 5 Q 25 0, 50 5 T 100 5" fill="none" stroke="currentColor" stroke-width="1.5"/>
+    <svg class="wave" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 48" preserveAspectRatio="none" aria-hidden="true">
+      <path d="M0 28 C 14 18 24 18 40 28 S 76 38 94 24 S 150 4 176 22 S 226 40 240 26" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
     </svg>
 
     <h1 class="site-title">Maja Ludvigsen</h1>
 
     <!-- vågig linje -->
-    <svg class="wave" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 10" preserveAspectRatio="none">
-      <path d="M0 5 Q 25 0, 50 5 T 100 5" fill="none" stroke="currentColor" stroke-width="1.5"/>
+    <svg class="wave" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 48" preserveAspectRatio="none" aria-hidden="true">
+      <path d="M0 28 C 14 18 24 18 40 28 S 76 38 94 24 S 150 4 176 22 S 226 40 240 26" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
     </svg>
 
     <!-- höger blomma -->

--- a/kontakt.html
+++ b/kontakt.html
@@ -33,15 +33,15 @@
     </svg>
 
     <!-- vågig linje -->
-    <svg class="wave" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 10" preserveAspectRatio="none">
-      <path d="M0 5 Q 25 0, 50 5 T 100 5" fill="none" stroke="currentColor" stroke-width="1.5"/>
+    <svg class="wave" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 48" preserveAspectRatio="none" aria-hidden="true">
+      <path d="M0 28 C 14 18 24 18 40 28 S 76 38 94 24 S 150 4 176 22 S 226 40 240 26" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
     </svg>
 
     <h1 class="site-title">Maja Ludvigsen</h1>
 
     <!-- vågig linje -->
-    <svg class="wave" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 10" preserveAspectRatio="none">
-      <path d="M0 5 Q 25 0, 50 5 T 100 5" fill="none" stroke="currentColor" stroke-width="1.5"/>
+    <svg class="wave" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 48" preserveAspectRatio="none" aria-hidden="true">
+      <path d="M0 28 C 14 18 24 18 40 28 S 76 38 94 24 S 150 4 176 22 S 226 40 240 26" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
     </svg>
 
     <!-- höger blomma -->

--- a/om-mig.html
+++ b/om-mig.html
@@ -33,15 +33,15 @@
     </svg>
 
     <!-- vågig linje -->
-    <svg class="wave" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 10" preserveAspectRatio="none">
-      <path d="M0 5 Q 25 0, 50 5 T 100 5" fill="none" stroke="currentColor" stroke-width="1.5"/>
+    <svg class="wave" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 48" preserveAspectRatio="none" aria-hidden="true">
+      <path d="M0 28 C 14 18 24 18 40 28 S 76 38 94 24 S 150 4 176 22 S 226 40 240 26" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
     </svg>
 
     <h1 class="site-title">Maja Ludvigsen</h1>
 
     <!-- vågig linje -->
-    <svg class="wave" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 10" preserveAspectRatio="none">
-      <path d="M0 5 Q 25 0, 50 5 T 100 5" fill="none" stroke="currentColor" stroke-width="1.5"/>
+    <svg class="wave" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 48" preserveAspectRatio="none" aria-hidden="true">
+      <path d="M0 28 C 14 18 24 18 40 28 S 76 38 94 24 S 150 4 176 22 S 226 40 240 26" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
     </svg>
 
     <!-- höger blomma -->

--- a/style.css
+++ b/style.css
@@ -61,7 +61,7 @@ body{
 }
 .header-decor .wave {
   flex: 1;
-  height: 20px;
+  height: 32px;
   width: 100%;
   display: block;
 }

--- a/tjanster.html
+++ b/tjanster.html
@@ -33,15 +33,15 @@
     </svg>
 
     <!-- vågig linje -->
-    <svg class="wave" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 10" preserveAspectRatio="none">
-      <path d="M0 5 Q 25 0, 50 5 T 100 5" fill="none" stroke="currentColor" stroke-width="1.5"/>
+    <svg class="wave" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 48" preserveAspectRatio="none" aria-hidden="true">
+      <path d="M0 28 C 14 18 24 18 40 28 S 76 38 94 24 S 150 4 176 22 S 226 40 240 26" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
     </svg>
 
     <h1 class="site-title">Maja Ludvigsen</h1>
 
     <!-- vågig linje -->
-    <svg class="wave" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 10" preserveAspectRatio="none">
-      <path d="M0 5 Q 25 0, 50 5 T 100 5" fill="none" stroke="currentColor" stroke-width="1.5"/>
+    <svg class="wave" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 48" preserveAspectRatio="none" aria-hidden="true">
+      <path d="M0 28 C 14 18 24 18 40 28 S 76 38 94 24 S 150 4 176 22 S 226 40 240 26" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
     </svg>
 
     <!-- höger blomma -->


### PR DESCRIPTION
## Summary
- replace the simple sinus SVG in each page header with a flowing line closer to the provided inspiration
- enlarge the header wave container so the new illustration has breathing room

## Testing
- no automated tests were run (static HTML/CSS change)


------
https://chatgpt.com/codex/tasks/task_e_68c86eac22d483339338a5bf440c15c9