### PR TITLE
Remove wave graphics from header and show logo on all pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,15 +12,8 @@
 <body>
 <header class="site-header">
   <div class="header-decor">
-
     <img class="header-logo" src="header-logo.png" alt="Turkos vågform" width="160" height="160" />
-    
     <h1 class="site-title">Maja Ludvigsen</h1>
-
-    <!-- vågig linje -->
-    <svg class="wave" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 48" preserveAspectRatio="none" aria-hidden="true">
-      <path d="M0 28 C 14 18 24 18 40 28 S 76 38 94 24 S 150 4 176 22 S 226 40 240 26" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
-    </svg>
   </div>
 
   <!-- Desktop meny -->

--- a/kontakt.html
+++ b/kontakt.html
@@ -12,18 +12,8 @@
 <body>
 <header class="site-header">
   <div class="header-decor">
-
-    <!-- vågig linje -->
-    <svg class="wave" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 48" preserveAspectRatio="none" aria-hidden="true">
-      <path d="M0 28 C 14 18 24 18 40 28 S 76 38 94 24 S 150 4 176 22 S 226 40 240 26" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
-    </svg>
-
+    <img class="header-logo" src="header-logo.png" alt="Turkos vågform" width="160" height="160" />
     <h1 class="site-title">Maja Ludvigsen</h1>
-
-    <!-- vågig linje -->
-    <svg class="wave" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 48" preserveAspectRatio="none" aria-hidden="true">
-      <path d="M0 28 C 14 18 24 18 40 28 S 76 38 94 24 S 150 4 176 22 S 226 40 240 26" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
-    </svg>
   </div>
 
   <!-- Desktop meny -->

--- a/om-mig.html
+++ b/om-mig.html
@@ -12,18 +12,8 @@
 <body>
 <header class="site-header">
   <div class="header-decor">
-
-    <!-- vågig linje -->
-    <svg class="wave" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 48" preserveAspectRatio="none" aria-hidden="true">
-      <path d="M0 28 C 14 18 24 18 40 28 S 76 38 94 24 S 150 4 176 22 S 226 40 240 26" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
-    </svg>
-
+    <img class="header-logo" src="header-logo.png" alt="Turkos vågform" width="160" height="160" />
     <h1 class="site-title">Maja Ludvigsen</h1>
-
-    <!-- vågig linje -->
-    <svg class="wave" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 48" preserveAspectRatio="none" aria-hidden="true">
-      <path d="M0 28 C 14 18 24 18 40 28 S 76 38 94 24 S 150 4 176 22 S 226 40 240 26" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
-    </svg>
   </div>
 
   <!-- Desktop meny -->

--- a/style.css
+++ b/style.css
@@ -53,12 +53,6 @@ body{
 .header-decor .flower{
   width:24px; height:24px;
 }
-.header-decor .wave {
-  flex: 1;
-  height: 32px;
-  width: 100%;
-  display: block;
-}
 .header-decor .site-title{
   font-family:"Cormorant Garamond", serif;
   font-weight:600;

--- a/tjanster.html
+++ b/tjanster.html
@@ -12,18 +12,8 @@
 <body>
 <header class="site-header">
   <div class="header-decor">
-   
-    <!-- vågig linje -->
-    <svg class="wave" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 48" preserveAspectRatio="none" aria-hidden="true">
-      <path d="M0 28 C 14 18 24 18 40 28 S 76 38 94 24 S 150 4 176 22 S 226 40 240 26" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
-    </svg>
-
+    <img class="header-logo" src="header-logo.png" alt="Turkos vågform" width="160" height="160" />
     <h1 class="site-title">Maja Ludvigsen</h1>
-
-    <!-- vågig linje -->
-    <svg class="wave" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 48" preserveAspectRatio="none" aria-hidden="true">
-      <path d="M0 28 C 14 18 24 18 40 28 S 76 38 94 24 S 150 4 176 22 S 226 40 240 26" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
-    </svg>
   </div>
 
   <!-- Desktop meny -->


### PR DESCRIPTION
## Summary
- remove the wavy SVG decoration from each page header
- keep the header logo and title as the sole header content across the site
- clean up the header styling by dropping the unused wave rule

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c87e51266c8333a323c651f4aee6c3